### PR TITLE
動画冒頭に人数分揃ってないとエラーになる問題を回避

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ born/*.csv
 *.html
 3DToVmd_semi.bat
 3DToVmdSelf.bat
+slope/slope_upper2 - コピー.vmd
+slope/slope_upper2_ジバニャン.vmd

--- a/3DToVmd.bat
+++ b/3DToVmd.bat
@@ -69,7 +69,7 @@ rem set /P CENTER_XY_SCALE="■センターXY移動倍率: "
 
 rem ---  センターZ移動倍率
 echo --------------
-set CENTER_Z_SCALE=5
+set CENTER_Z_SCALE=0
 echo センターZ移動に掛ける倍率を数値(小数可)で入力して下さい。
 echo 値が小さいほど、センターZ移動の幅が小さくなります。
 echo 目安として、カメラからの距離が近いほど、倍率を小さくした方がいいです。

--- a/3DToVmd_en.bat
+++ b/3DToVmd_en.bat
@@ -68,7 +68,7 @@ rem set /P CENTER_XY_SCALE="** Center XY Magnification: "
 
 rem ---  ÉZÉìÉ^Å[Zà⁄ìÆî{ó¶
 echo --------------
-set CENTER_Z_SCALE=5
+set CENTER_Z_SCALE=0
 echo Please enter the magnification multiplied by the center Z movement with a numerical value (decimal possible).
 echo The smaller the value, the smaller the width of the center Z movement.
 echo As a guide, it is better to reduce the magnification as the distance from the camera is shorter.

--- a/applications/pos2vmd_frame.py
+++ b/applications/pos2vmd_frame.py
@@ -15,6 +15,10 @@ logger = logging.getLogger("__main__").getChild(__name__)
 def position_to_frame(bone_frame_dic, pos, pos_gan, smoothed_2d, frame, is_upper2_body, slope_motion):
     logger.debug("角度計算 frame={0}".format(str(frame)))
 
+    # 上半身の方向の安定化のため脊椎を20mm後ろへ動かす(LSld, RSld, Hipでできる平面の垂直方向へ動かす)
+    up = QVector3D.crossProduct((pos[0] - pos[14]), (pos[14] - pos[11])).normalized()
+    pos[7] += up * 20
+
     # 体幹の回転
     upper_body_rotation1, upper_body_rotation2, upper_correctqq, lower_body_rotation, lower_correctqq, is_gan \
         = position_to_frame_trunk(bone_frame_dic, frame, pos, pos_gan, is_upper2_body, slope_motion)
@@ -38,10 +42,10 @@ def position_to_frame(bone_frame_dic, pos, pos_gan, smoothed_2d, frame, is_upper
     bf.rotation = lower_body_rotation
     bone_frame_dic["下半身"].append(bf)
 
-    # 頭の方向の安定化のためNeck/NoseとHeadを20mm前へ動かす(LSld, RSld, Hipでできる平面の垂直方向へ動かす)
+    # 頭の方向の安定化のためNeck/NoseとHeadを500mm後ろへ動かす(LSld, RSld, Hipでできる平面の垂直方向へ動かす)
     up = QVector3D.crossProduct((pos[0] - pos[14]), (pos[14] - pos[11])).normalized()
-    pos[9] += up * 20
-    pos[10] += up * 20
+    pos[9] += up * 500
+    pos[10] += up * 500
 
     neck_rotation, head_rotation = \
         position_to_frame_head(frame, pos, pos_gan, upper_body_rotation1, upper_body_rotation2, upper_correctqq, is_gan, slope_motion)


### PR DESCRIPTION
・　動画冒頭に人数分揃ってないとエラーになる問題を回避
・　【深度推定】を、深度推定処理と人物INDEX並び替え処理に分割
・　首・頭・上半身2の角度調整
・　vmd出力ファイルの命名規則を変更
・　しゃがんで停止するモーションで、たまに人物が滑ってしまう問題を解決 (kenkra様）
